### PR TITLE
[fix] do not wrap "placeholder" text but instead show ellipsis

### DIFF
--- a/src/components/Placeholder.js
+++ b/src/components/Placeholder.js
@@ -5,6 +5,9 @@ import getTheme from '../utils/getTheme';
 const Placeholder = styled.div`
     font-size: ${getTheme('fontSize')};
     color: ${getTheme('placeHolderColor')};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 `;
 
 export default Placeholder;


### PR DESCRIPTION
When on smaller screens a large placeholder text _(e.g. one with many filters)_ wraps and is shown outside the container.

This solution is similar to the default behaviour of `<input \>` (except for the ellipsis)